### PR TITLE
remove the focus ring of status bar

### DIFF
--- a/xVim/View.xib
+++ b/xVim/View.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
 		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">11C74</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
-		<string key="IBDocument.AppKitVersion">1138.23</string>
-		<string key="IBDocument.HIToolboxVersion">567.00</string>
+		<string key="IBDocument.SystemVersion">11D50</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2177</string>
+		<string key="IBDocument.AppKitVersion">1138.32</string>
+		<string key="IBDocument.HIToolboxVersion">568.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1938</string>
+			<string key="NS.object.0">2177</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -46,14 +46,15 @@
 						<int key="NSvFlags">268</int>
 						<string key="NSFrame">{{63, 134}, {355, 22}}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<string key="NSReuseIdentifierKey">_NS:903</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="956222729">
 							<int key="NSCellFlags">-1800274367</int>
-							<int key="NSCellFlags2">272630848</int>
+							<int key="NSCellFlags2">272663616</int>
 							<string key="NSContents">aaaaaa</string>
 							<object class="NSFont" key="NSSupport">
-								<string key="NSName">EspressoMono-Regular</string>
+								<string key="NSName">LucidaGrande</string>
 								<double key="NSSize">12</double>
 								<int key="NSfFlags">16</int>
 							</object>
@@ -73,6 +74,7 @@
 				</object>
 				<string key="NSFrameSize">{480, 272}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="297837074"/>
 				<string key="NSClassName">NSView</string>
 			</object>
@@ -146,7 +148,7 @@
 					<string>2.IBPluginDependency</string>
 					<string>3.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>

--- a/xVim/xVim-Info.plist
+++ b/xVim/xVim-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>495</string>
+	<string>496</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2011年 http://warwithinme.com . All rights reserved.</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
On Xcode 4.3 the focus ring of status bar will show even not in command mode
